### PR TITLE
fix: keep automatic night light from sticking at night

### DIFF
--- a/glimpse-core/src/services/location.rs
+++ b/glimpse-core/src/services/location.rs
@@ -161,7 +161,9 @@ impl LocationService {
                         },
                         ServiceCommand::Command(service_command) => match service_command {
                             Command::Refresh => {
-                                self.change_state(State::Refreshing);
+                                if !matches!(*self.state_tx.borrow(), State::Ready(_)) {
+                                    self.change_state(State::Refreshing);
+                                }
                                 match lifecycle {
                                     Lifecycle::Running(ref provider) => {
                                         provider.send(ProviderCommand::Refresh).await;
@@ -309,10 +311,32 @@ mod tests {
     use super::{Command, LocationService, State};
     use crate::{
         Config,
-        services::framework::{Control, ServiceCommand},
+        services::{
+            framework::{Control, ServiceCommand, ServiceHandle},
+            geoclue,
+        },
     };
-    use tokio::time::{Duration, timeout};
+    use tokio::{
+        sync::{mpsc, watch},
+        time::{Duration, timeout},
+    };
     use tokio_util::sync::CancellationToken;
+
+    fn geoclue_handle(
+        initial: geoclue::State,
+    ) -> (
+        watch::Sender<geoclue::State>,
+        geoclue::GeoClueHandle,
+        mpsc::Receiver<ServiceCommand<geoclue::Command>>,
+    ) {
+        let (state_tx, state_rx) = watch::channel(initial);
+        let (command_tx, command_rx) = mpsc::channel(4);
+        (
+            state_tx,
+            ServiceHandle::new(state_rx, command_tx),
+            command_rx,
+        )
+    }
 
     async fn wait_for_state(
         rx: &mut tokio::sync::watch::Receiver<State>,
@@ -368,6 +392,70 @@ mod tests {
         })
         .await
         .expect("refresh should settle back to degraded");
+
+        cancel.cancel();
+        timeout(Duration::from_secs(1), task)
+            .await
+            .expect("location task should exit after cancellation")
+            .expect("location task should not panic");
+    }
+
+    #[tokio::test]
+    async fn refresh_preserves_ready_coordinates_until_provider_updates() {
+        let (_geoclue_tx, geoclue, mut geoclue_commands) = geoclue_handle(geoclue::State {
+            available: true,
+            coordinates: Some(geoclue::Coordinates {
+                latitude: 52.0,
+                longitude: 21.0,
+            }),
+            ..geoclue::State::default()
+        });
+        let (service, handle) = LocationService::new(geoclue);
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            service.run(task_cancel).await;
+        });
+        let mut rx = handle.subscribe();
+
+        handle
+            .send(ServiceCommand::Control(Control::Start(Config::default())))
+            .await
+            .expect("start location service");
+        wait_for_state(&mut rx, |state| matches!(state, State::Ready(_))).await;
+
+        handle
+            .send(ServiceCommand::Command(Command::Refresh))
+            .await
+            .expect("refresh location service");
+
+        let saw_refreshing = timeout(Duration::from_secs(1), async {
+            loop {
+                tokio::select! {
+                    changed = rx.changed() => {
+                        changed.expect("location service should run");
+                        if matches!(*rx.borrow(), State::Refreshing) {
+                            break true;
+                        }
+                    }
+                    command = geoclue_commands.recv() => {
+                        assert!(matches!(
+                            command,
+                            Some(ServiceCommand::Command(geoclue::Command::Refresh))
+                        ));
+                        break false;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("location refresh should be forwarded to GeoClue");
+
+        assert!(
+            !saw_refreshing,
+            "refreshing a ready location should keep the cached coordinates available"
+        );
+        assert!(matches!(handle.snapshot(), State::Ready(_)));
 
         cancel.cancel();
         timeout(Duration::from_secs(1), task)

--- a/glimpse-core/src/services/night_light.rs
+++ b/glimpse-core/src/services/night_light.rs
@@ -237,7 +237,14 @@ async fn apply_config(
     }
 
     let (phase, effective_temperature) =
-        resolve_effective_temperature(&config, solar, manual_override).await?;
+        match resolve_effective_temperature(&config, solar, manual_override).await {
+            Ok(effective) => effective,
+            Err(error) if error.to_string() == SOLAR_UNAVAILABLE_MESSAGE => {
+                tracing::debug!("night light service: waiting for solar times; using daylight");
+                (NightLightPhase::Day, DAYLIGHT_TEMPERATURE_KELVIN)
+            }
+            Err(error) => return Err(error),
+        };
 
     apply_temperature_transition(
         compositor,
@@ -491,11 +498,11 @@ fn current_local_time() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        SOLAR_UNAVAILABLE_MESSAGE, State, compositor_night_light_changed, resolve_solar_snapshot,
-        transition_temperatures,
+        SOLAR_UNAVAILABLE_MESSAGE, State, apply_config, compositor_night_light_changed,
+        resolve_solar_snapshot, transition_temperatures,
     };
     use crate::{
-        Config, NightLightConfig, NightLightPhase, NightLightSchedule,
+        Config, DAYLIGHT_TEMPERATURE_KELVIN, NightLightConfig, NightLightPhase, NightLightSchedule,
         compositors::{CompositorCapabilities, CompositorType},
         services::{
             compositor::{Command as CompositorCommand, State as CompositorState},
@@ -523,7 +530,7 @@ mod tests {
             capabilities,
             ..CompositorState::default()
         });
-        let (command_tx, command_rx) = mpsc::channel(4);
+        let (command_tx, command_rx) = mpsc::channel(32);
         (
             state_tx,
             ServiceHandle::new(state_rx, command_tx),
@@ -604,6 +611,55 @@ mod tests {
         let error = resolve_solar_snapshot(&solar).expect_err("solar times should be unavailable");
 
         assert_eq!(error.to_string(), SOLAR_UNAVAILABLE_MESSAGE);
+    }
+
+    #[tokio::test]
+    async fn automatic_schedule_resets_stale_night_state_when_solar_is_unavailable() {
+        let (_solar_tx, solar) = solar_handle(solar::State::Unknown);
+        let (_compositor_tx, compositor, mut compositor_rx) =
+            compositor_handle(CompositorCapabilities {
+                night_light: true,
+                ..CompositorCapabilities::default()
+            });
+        let config = NightLightConfig {
+            schedule: NightLightSchedule::Automatic,
+            temperature: 4200,
+            ..NightLightConfig::default()
+        };
+        let (state_tx, _state_rx) = watch::channel(State {
+            compositor: CompositorType::Niri,
+            config: config.clone(),
+            phase: NightLightPhase::Night,
+            manual_override: None,
+            current_temperature_kelvin: 4200,
+            target_temperature_kelvin: 4200,
+            effective_temperature_kelvin: 4200,
+        });
+
+        apply_config(&solar, &compositor, &state_tx, config, None)
+            .await
+            .expect("unavailable solar data should fall back to daylight");
+
+        let state = state_tx.borrow().clone();
+        assert_eq!(state.phase, NightLightPhase::Day);
+        assert_eq!(
+            state.effective_temperature_kelvin,
+            DAYLIGHT_TEMPERATURE_KELVIN
+        );
+        assert_eq!(state.target_temperature_kelvin, 4200);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if matches!(
+                    next_compositor_command(&mut compositor_rx).await,
+                    CompositorCommand::ResetNightLight
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("daylight fallback should reset the compositor");
     }
 
     #[tokio::test]

--- a/glimpse-core/src/services/weather/service.rs
+++ b/glimpse-core/src/services/weather/service.rs
@@ -170,15 +170,13 @@ async fn resolve_forecast_location(
     }
 
     let mut subscription = location.subscribe();
-    // Always trigger a refresh so we don't paint weather with stale coordinates
-    // (e.g., after the user moved on a flight or train). The cached fix is
-    // used immediately as a fallback while the fresh refresh runs in the
-    // background; when fresh coords arrive, the outer weather loop re-fetches
-    // via the location-changed signal.
-    request_location_refresh(location).await;
     if let Some(location) = location_from_state(&subscription.borrow()) {
         return Ok(ForecastLocation::Coordinates(location));
     }
+
+    // If there is no cached fix, trigger GeoClue and wait for the first usable
+    // coordinates. Later fresh coords are handled by the location-changed path.
+    request_location_refresh(location).await;
 
     timeout(LOCATION_WAIT, async {
         loop {
@@ -236,6 +234,18 @@ fn should_refetch_for_location_change(config: &Option<Config>, state: &location:
 mod tests {
     use super::*;
     use crate::services::location::{Coordinates, State as LocationState};
+    use tokio::sync::{mpsc, watch};
+
+    fn location_handle(
+        initial: LocationState,
+    ) -> (
+        location::LocationHandle,
+        mpsc::Receiver<ServiceCommand<location::Command>>,
+    ) {
+        let (_state_tx, state_rx) = watch::channel(initial);
+        let (command_tx, command_rx) = mpsc::channel(4);
+        (ServiceHandle::new(state_rx, command_tx), command_rx)
+    }
 
     #[test]
     fn location_from_state_maps_ready_coordinates() {
@@ -284,5 +294,28 @@ mod tests {
                 longitude: 21.0118,
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn ready_location_is_used_without_requesting_another_refresh() {
+        let (location, mut command_rx) = location_handle(LocationState::Ready(Coordinates {
+            latitude: 52.2298,
+            longitude: 21.0118,
+        }));
+
+        let forecast_location = resolve_forecast_location(&Config::default(), &location)
+            .await
+            .expect("ready location should resolve");
+
+        assert!(matches!(
+            forecast_location,
+            ForecastLocation::Coordinates(_)
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), command_rx.recv())
+                .await
+                .is_err(),
+            "cached ready coordinates should not trigger another location refresh"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- preserve cached ready location coordinates while a refresh is in flight
- avoid weather immediately re-requesting location when ready coordinates are already available
- reset automatic night-light to daylight when solar times become unavailable instead of keeping stale warm state

## Verification
- cargo fmt -p glimpse-core --check
- cargo test -p glimpse-core
- just e2e-shell

## Notes
- attempted cargo test --workspace; the first run failed due disk quota in /tmp and the retry was stopped when cleaning up running processes